### PR TITLE
Nhse d30 eldb275

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -1,11 +1,11 @@
-LEVELDB_VSN ?= "nhse-develop-3.0"
+export LEVELDB_VSN ?= "nhse-d30-eldb275"
 SNAPPY_VSN ?= "1.1.9"
 BASEDIR = $(shell pwd)
 
-LDFLAGS := $(LDFLAGS) -L$(BASEDIR)/system/lib
-LD_LIBRARY_PATH := $(BASEDIR)/system/lib:$(LD_LIBRARY_PATH)
-CFLAGS := $(CFLAGS) -I $(BASEDIR)/system/include -I. -I $(BASEDIR)/leveldb/include -fPIC
-CXXFLAGS := $(CXXFLAGS) -I $(BASEDIR)/system/include -I. -I $(BASEDIR)/leveldb/include -fPIC
+export LDFLAGS := $(LDFLAGS) -L$(BASEDIR)/system/lib
+export LD_LIBRARY_PATH := $(BASEDIR)/system/lib:$(LD_LIBRARY_PATH)
+export CFLAGS := $(CFLAGS) -I $(BASEDIR)/system/include -I. -I $(BASEDIR)/leveldb/include -fPIC
+export CXXFLAGS := $(CXXFLAGS) -I $(BASEDIR)/system/include -I. -I $(BASEDIR)/leveldb/include -fPIC
 
 get-deps:
 	if [ ! -r snappy-$(SNAPPY_VSN).tar.gz ]; then \

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -1,4 +1,4 @@
-export LEVELDB_VSN ?= "nhse-d30-eldb275"
+export LEVELDB_VSN ?= "nhse-develop-3.0"
 SNAPPY_VSN ?= "1.1.9"
 BASEDIR = $(shell pwd)
 

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -6,7 +6,8 @@
 %% actually running.
 case os:type() of
     {unix,darwin} ->
-        Opt = " -mmacosx-version-min=10.8 -stdlib=libc++ -std=c++11",
+        OSXVersion = re:replace(os:cmd("sw_vers -productVersion"), "[\n]", "", [global, {return, list}]),
+        Opt = " -mmacosx-version-min=" ++ OSXVersion ++ " -stdlib=libc++ -std=c++11",
         [Mjr|_] = string:tokens(os:cmd("/usr/bin/uname -r"), "."),
         Major = list_to_integer(Mjr),
         if

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -6,7 +6,7 @@
 %% actually running.
 case os:type() of
     {unix,darwin} ->
-        Opt = " -mmacosx-version-min=10.8 -stdlib=libc++",
+        Opt = " -mmacosx-version-min=10.8 -stdlib=libc++ -std=c++11",
         [Mjr|_] = string:tokens(os:cmd("/usr/bin/uname -r"), "."),
         Major = list_to_integer(Mjr),
         if


### PR DESCRIPTION
The process for installing eleveldb is as follows:

- rebar.config has a pre-hook to run the Makefile in c_src https://github.com/nhs-riak/eleveldb/blob/251f4321b3e4ccb4283965cfc1e1eb46ca30b37f/rebar.config#L33-L34 for `get-deps` and `compile`
- this Makefile determines some environment variables, in particular FLAGS to instruct future downstream compilations to refer to `c_src/system/lib` and `c_src/system/include` where the snappy compression code will be held
- the Makefile will then clone leveldb and fetch the required version of snappy from github as part of the `get_deps` stage.
- in the `compile` stage, initially Snappy is compiled, into the `c_src/systerm` directory https://github.com/nhs-riak/eleveldb/blob/251f4321b3e4ccb4283965cfc1e1eb46ca30b37f/c_src/Makefile#L36-L43
- once snappy has been compiled and moved, there is a call to make leveldb
- the leveldb Makefile uses the `leveldb/build_detect_platform` script to create a `build_config.mk` to be used in this make process - https://github.com/nhs-riak/leveldb/blob/2fd90c712af1ac9609ef9c1adba98814fb6751ef/Makefile#L18-L23
- the build_detect_platform sets flags based on the OS https://github.com/nhs-riak/leveldb/blob/2fd90c712af1ac9609ef9c1adba98814fb6751ef/build_detect_platform#L63
- the build_detect_platform then sets further flags based on the availability of features, including the installation of snappy.  The installation of snappy is detected by compiling some code which includes snappy.h and confirming the compilation has an exit code of 0 https://github.com/nhs-riak/leveldb/blob/2fd90c712af1ac9609ef9c1adba98814fb6751ef/build_detect_platform#L171-L175
- the build_detect_platform script will also detect the presence of leveldb_ee (legacy enterprise version) https://github.com/nhs-riak/leveldb/blob/2fd90c712af1ac9609ef9c1adba98814fb6751ef/build_detect_platform#L135-L139 which should be present due to the of leveldb in .gitmodules as a submodule 
- with the `build_config.mk` file complete and included, the Makefile will then make leveldb using https://github.com/nhs-riak/leveldb/blob/2fd90c712af1ac9609ef9c1adba98814fb6751ef/Makefile#L86
- once this stage is complete, the `pre-hook` is done, and so eleveldb is compiled using the `post` provider_hook https://github.com/nhs-riak/eleveldb/blob/251f4321b3e4ccb4283965cfc1e1eb46ca30b37f/rebar.config#L7-L16
- flags for this stage of compilation are generated using [rebar.config port_env](https://github.com/nhs-riak/eleveldb/blob/251f4321b3e4ccb4283965cfc1e1eb46ca30b37f/rebar.config#L25-L31) which are supplemented with OS-specific flags by running the [rebar.config.script](https://github.com/nhs-riak/eleveldb/blob/251f4321b3e4ccb4283965cfc1e1eb46ca30b37f/rebar.config.script)

The issues this PR addresses are:

- a failure to export the FLAGS from `eleveldb/c_src/Makefile` means that those flags were not set for downstream Makefiles, and so the test for snappy presence would not compile due to the absence of the include directives in the CFLAGS
- on OSX snappy would silently fail to compile due to a requirement to enforce support for at least the c++11 standard.  Fixing this requires changes to both the OS-specific setting in `build_detect_platform` (for compiling snappy/leveldb) and the `rebar.config.script` (for compiling eleveldb)
- snappy will no longer compile on OSX 10.8, as there is no intention to build portable packages for OSX, the OSX min version is instead defaulted to the current version (avoiding warnings)