### PR TITLE
Update LZ4 to 1.9.4

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -2,9 +2,9 @@ name: Erlang CI
 
 on:
   push:
-    branches: [ develop-3.0 ]
+    branches: [ nhse-develop-3.2 ]
   pull_request:
-    branches: [ develop-3.0 ]
+    branches: [ nhse-develop-3.2 ]
 
 
 jobs:

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -1,4 +1,4 @@
-export LEVELDB_VSN ?= "nhse-develop-3.0"
+export LEVELDB_VSN ?= "nhse-develop"
 SNAPPY_VSN ?= "1.1.9"
 BASEDIR = $(shell pwd)
 


### PR DESCRIPTION
Bring in updated leveldb which updates lz4 to 1.9.4.  This makes eleveldb consistent with leveled in terms of lz4 code - stopping compiler warnings, and reducing the potential for future compilation issues by having two different versions.